### PR TITLE
Prevent multiple IN predicates to the same attribute

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -841,6 +841,7 @@ module ActiveRecord
 
     def where!(opts, *rest) # :nodoc:
       self.where_clause += build_where_clause(opts, rest)
+      self.where_clause = self.where_clause.merge_homogenous_in_predicates
       self
     end
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

When monitoring the killed queries in our DB, we noted that several of them had duplicated/triplicated `... table.id IN (?) ...` clauses, and given the size of the lists, the queries were huge. We manually resolved some of them, reducing the number of killed queries considerably. I believe the SQL string size was the main factor for them to take so long on some DB phases and end up being killed.

It happened because the AssociationRelation object is passed through several layers, and we apply new scopes to filter the results once the query is performed. 

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Although we could try to make sure we add the IN clause only once, it doesn't seem achievable without accessing some methods like `#where_values_hash` and other internal methods. And even if there were easy ways to check it, it would add a lot of overhead to be always checking/extracting the IN clause and intersecting the elements before adding a new clause. It would also be error-prone since it would be easy to forget.

Therefore, I think it is safe to merge the HomogeneousIn predicates by intersecting the elements as they are added to the where chain. And by doing that, the where_clause will have at least fewer predicates. These IN predicates will be as short as possible, being at max the size of the smaller list.

### Details

This Pull Request changes the SQL generated for

```ruby
class Post < ActiveRecord::Base
end

post_scope = Post.where(id: [1,2,3])
  .where(id: [1,2,3])
  .where(id: [3,2,1])
  .where(id: ["3",4,5])

puts post_scope.to_sql
```

Before this PR:
```SQL
SELECT "posts".*
FROM "posts" 
WHERE "posts"."id" IN (1, 2, 3)
AND "posts"."id" IN (1, 2, 3)
AND "posts"."id" IN (3, 2, 1)
AND "posts"."id" IN (3, 4, 5)
```

After this PR:
```SQL
SELECT "posts".* 
FROM "posts"
WHERE "posts"."id" IN (3)
```

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

To benchmark the new code, I had to manually edit the code to comment the call to `WhereClause#merge_homogenous_in_predicates`. The code ended up:

```
    def where!(opts, *rest) # :nodoc:
      self.where_clause += build_where_clause(opts, rest)
      # self.where_clause = self.where_clause.merge_homogenous_in_predicates
      self
    end
```

I ran the benchmark code below to evaluate the changes. The conclusion is that the improvement scale for the `#to_sql` method is huge and there is a ~70-80% reduction in the size of the SQL string generated, but it comes with an impact when calling the `#where` method.

```
================================ Two items list ================================

Comparison:
where merging HomogenousIn predicates: 224248496534460288.0 i/s
               where: 207045169235058368.0 i/s - same-ish: difference falls within error

Comparison:
SQL string generation merging HomogenousIn predicates: 56633178238747752.0 i/s
SQL string generation: 105123501895656.2 i/s - 538.73x  (± 0.00) slower

Compare SQL string size -------------------------------------
Current: 193
Candidate: 58
Result 69.95% smaller

============================ Mixed type items list =============================

Comparison:
               where: 210817344851444160.0 i/s
where merging HomogenousIn predicates: 169025596127563616.0 i/s - same-ish: difference falls within error

Comparison:
SQL string generation merging HomogenousIn predicates: 46002191907273072.0 i/s
SQL string generation: 39056953682349.5 i/s - 1177.82x  (± 0.00) slower

Compare SQL string size -------------------------------------
Current: 211
Candidate: 61
Result 71.09% smaller

=============================== Long items list ================================

Comparison:
               where: 67817182733647616.0 i/s
where merging HomogenousIn predicates: 5094194034429827.0 i/s - 13.31x  (± 0.00) slower

Comparison:
SQL string generation merging HomogenousIn predicates: 1569706558951527.0 i/s
SQL string generation: 1292567011903.2 i/s - 1214.41x  (± 0.00) slower

Compare SQL string size -------------------------------------
Current: 2509
Candidate: 444
Result 82.3% smaller

============================= Very Long items list =============================

Comparison:
               where: 127526863868727.1 i/s
where merging HomogenousIn predicates: 2582651998284.5 i/s - 49.38x  (± 0.00) slower

Comparison:
SQL string generation merging HomogenousIn predicates: 842996759394.6 i/s
SQL string generation:   397794.5 i/s - 2119176.74x  (± 0.00) slower

Compare SQL string size -------------------------------------
Current: 173515
Candidate: 28945
Result 83.32% smaller
```

<details>
  <summary>Benchmark Code</summary>

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", path: "../rails"
  gem "sqlite3"
  gem "debug"
  gem "benchmark-ips"
end

require "active_record"
require "logger"
require 'benchmark/ips'

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
  end
end

class Post < ActiveRecord::Base
end

# Enumerate some representative scenarios here.
#
# It is very easy to make an optimization that improves performance for a
# specific scenario you care about but regresses on other common cases.
# Therefore, you should test your change against a list of representative
# scenarios. Ideally, they should be based on real-world scenarios extracted
# from production applications.
SCENARIOS = {
  "Two items list"        => [1, 2],
  "Mixed type items list" => [1, "2", 3],
  "Long items list"  => (1..100).to_a,
  "Very Long items list"  => (1..5000).to_a
}

SCENARIOS.each_pair do |name, value|
  puts
  puts " #{name} ".center(80, "=")
  puts

  post_scope = Post.where(id: value)
  post_scope_candidate = Post.where(id: value)

  Benchmark.ips do |x|
    x.report("where") do | times |
      # Commented the self.where_clause = self.where_clause.merge_homogenous_in_predicates
      # in order to run the code with the same rails version
      post_scope = post_scope.where(id: value)
    end

    x.report("where merging HomogenousIn predicates") do | times |
      post_scope_candidate = post_scope_candidate.where(id: value)
      post_scope_candidate.where_clause = post_scope_candidate.where_clause.merge_homogenous_in_predicates
    end

    x.compare!
  end

  post_scope = Post.where(id: value)
  post_scope_candidate = Post.where(id: value)

  Benchmark.ips do |x|
    x.report("SQL string generation") do | times |
      post_scope = post_scope.where(id: value)
      post_scope.to_sql
    end

    x.report("SQL string generation merging HomogenousIn predicates") do | times |
      post_scope_candidate = post_scope_candidate.where(id: value)
      post_scope_candidate.where_clause = post_scope_candidate.where_clause.merge_homogenous_in_predicates
      post_scope_candidate.to_sql
    end

    x.compare!
  end

  post_scope = Post.where(id: value)
  post_scope_candidate = Post.where(id: value)
  (1..5).each do
    post_scope = post_scope.where(id: value)
    post_scope_candidate = post_scope_candidate.where(id: value)
    post_scope_candidate.where_clause = post_scope_candidate.where_clause.merge_homogenous_in_predicates
  end

  current_sql_string_byte_size = post_scope.to_sql.bytesize
  candidate_sql_string_byte_size = post_scope_candidate.to_sql.bytesize


  puts "Compare SQL string size -------------------------------------"
  puts "Current: #{current_sql_string_byte_size}"
  puts "Candidate: #{candidate_sql_string_byte_size}"
  puts "Result #{(100*(current_sql_string_byte_size-candidate_sql_string_byte_size)/current_sql_string_byte_size.to_f).round(2)}% smaller"
end
```

</details>

<details>
  <summary>Raw results</summary>

```
================================ Two items list ================================

Warming up --------------------------------------
               where     7.041T i/100ms
where merging HomogenousIn predicates
                         4.965T i/100ms
Calculating -------------------------------------
               where    207.045Q (±25.3%) i/s -    360.144Q in   4.986716s
where merging HomogenousIn predicates
                        224.248Q (± 9.1%) i/s - 1081820334740425216.000  in   4.945506s

Comparison:
where merging HomogenousIn predicates: 224248496534460288.0 i/s
               where: 207045169235058368.0 i/s - same-ish: difference falls within error

Warming up --------------------------------------
SQL string generation
                       584.747B i/100ms
SQL string generation merging HomogenousIn predicates
                         2.468T i/100ms
Calculating -------------------------------------
SQL string generation
                        105.124T (±20.4%) i/s -    505.806T in   5.005490s
SQL string generation merging HomogenousIn predicates
                         56.633Q (± 9.9%) i/s -    275.265Q in   4.960900s

Comparison:
SQL string generation merging HomogenousIn predicates: 56633178238747752.0 i/s
SQL string generation: 105123501895656.2 i/s - 538.73x  (± 0.00) slower

Compare SQL string size -------------------------------------
Current: 193
Candidate: 58
Result 69.95% smaller

============================ Mixed type items list =============================

Warming up --------------------------------------
               where     7.557T i/100ms
where merging HomogenousIn predicates
                         4.398T i/100ms
Calculating -------------------------------------
               where    210.817Q (±24.3%) i/s -    347.727Q in   4.986523s
where merging HomogenousIn predicates
                        169.026Q (±11.1%) i/s -    812.912Q in   4.951195s

Comparison:
               where: 210817344851444160.0 i/s
where merging HomogenousIn predicates: 169025596127563616.0 i/s - same-ish: difference falls within error

Warming up --------------------------------------
SQL string generation
                       267.321B i/100ms
SQL string generation merging HomogenousIn predicates
                         2.264T i/100ms
Calculating -------------------------------------
SQL string generation
                         39.057T (±20.5%) i/s -    187.927T in   5.005464s
SQL string generation merging HomogenousIn predicates
                         46.002Q (±10.7%) i/s -    222.848Q in   4.959493s

Comparison:
SQL string generation merging HomogenousIn predicates: 46002191907273072.0 i/s
SQL string generation: 39056953682349.5 i/s - 1177.82x  (± 0.00) slower

Compare SQL string size -------------------------------------
Current: 211
Candidate: 61
Result 71.09% smaller

=============================== Long items list ================================

Warming up --------------------------------------
               where     3.450T i/100ms
where merging HomogenousIn predicates
                       757.714B i/100ms
Calculating -------------------------------------
               where     67.817Q (±20.8%) i/s -    166.652Q in   4.985645s
where merging HomogenousIn predicates
                          5.094Q (± 6.5%) i/s -     25.167Q in   4.991253s

Comparison:
               where: 67817182733647616.0 i/s
where merging HomogenousIn predicates: 5094194034429827.0 i/s - 13.31x  (± 0.00) slower

Warming up --------------------------------------
SQL string generation
                        34.717B i/100ms
SQL string generation merging HomogenousIn predicates
                       419.021B i/100ms
Calculating -------------------------------------
SQL string generation
                          1.293T (±19.2%) i/s -      6.284T in   5.035644s
SQL string generation merging HomogenousIn predicates
                          1.570Q (± 7.0%) i/s -      7.778Q in   4.993582s

Comparison:
SQL string generation merging HomogenousIn predicates: 1569706558951527.0 i/s
SQL string generation: 1292567011903.2 i/s - 1214.41x  (± 0.00) slower

Compare SQL string size -------------------------------------
Current: 2509
Candidate: 444
Result 82.3% smaller

============================= Very Long items list =============================

Warming up --------------------------------------
               where   118.368B i/100ms
where merging HomogenousIn predicates
                        17.042B i/100ms
Calculating -------------------------------------
               where    127.527T (± 5.1%) i/s -    620.128T in   4.998609s
where merging HomogenousIn predicates
                          2.583T (± 4.0%) i/s -     12.901T in   5.003797s

Comparison:
               where: 127526863868727.1 i/s
where merging HomogenousIn predicates: 2582651998284.5 i/s - 49.38x  (± 0.00) slower

Warming up --------------------------------------
SQL string generation
                        74.156k i/100ms
SQL string generation merging HomogenousIn predicates
                         9.314B i/100ms
Calculating -------------------------------------
SQL string generation
                        397.794k (±19.8%) i/s -      2.002M in   5.224603s
SQL string generation merging HomogenousIn predicates
                        842.997B (± 1.6%) i/s -      4.219T in   5.006597s

Comparison:
SQL string generation merging HomogenousIn predicates: 842996759394.6 i/s
SQL string generation:   397794.5 i/s - 2119176.74x  (± 0.00) slower

Compare SQL string size -------------------------------------
Current: 173515
Candidate: 28945
Result 83.32% smaller
```

</details>

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
