### PR TITLE
Test different approach

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -652,7 +652,11 @@ module ActiveRecord
           elsif insert.update_duplicates?
             sql << " ON DUPLICATE KEY UPDATE "
             if insert.raw_update_sql?
-              sql = +"INSERT #{insert.into} #{insert.values_list} ON DUPLICATE KEY UPDATE #{insert.raw_update_sql}"
+              if insert.raw_update_sql_aliased?
+                sql << insert.raw_update_sql
+              else
+                sql = +"INSERT #{insert.into} #{insert.values_list} ON DUPLICATE KEY UPDATE #{insert.raw_update_sql}"
+              end
             else
               sql << insert.touch_model_timestamps_unless { |column| "#{insert.model.quoted_table_name}.#{column}<=>#{values_alias}.#{column}" }
               sql << insert.updatable_columns.map { |column| "#{column}=#{values_alias}.#{column}" }.join(",")

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -652,7 +652,7 @@ module ActiveRecord
           elsif insert.update_duplicates?
             sql << " ON DUPLICATE KEY UPDATE "
             if insert.raw_update_sql?
-              sql << insert.raw_update_sql
+              sql = +"INSERT #{insert.into} #{insert.values_list} ON DUPLICATE KEY UPDATE #{insert.raw_update_sql}"
             else
               sql << insert.touch_model_timestamps_unless { |column| "#{insert.model.quoted_table_name}.#{column}<=>#{values_alias}.#{column}" }
               sql << insert.updatable_columns.map { |column| "#{column}=#{values_alias}.#{column}" }.join(",")

--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -15,10 +15,11 @@ module ActiveRecord
       end
     end
 
-    def initialize(model, connection, inserts, on_duplicate:, update_only: nil, returning: nil, unique_by: nil, record_timestamps: nil)
+    def initialize(model, connection, inserts, on_duplicate:, update_only: nil, returning: nil, unique_by: nil, record_timestamps: nil, on_duplicate_raw_sql_aliased: false)
       @model, @connection, @inserts = model, connection, inserts.map(&:stringify_keys)
       @on_duplicate, @update_only, @returning, @unique_by = on_duplicate, update_only, returning, unique_by
       @record_timestamps = record_timestamps.nil? ? model.record_timestamps : record_timestamps
+      @update_raw_sql_aliased = on_duplicate_raw_sql_aliased
 
       disallow_raw_sql!(on_duplicate)
       disallow_raw_sql!(returning)
@@ -98,7 +99,12 @@ module ActiveRecord
       end
     end
 
+    def update_raw_sql_aliased?
+      custom_update_sql_provided? && @update_raw_sql_aliased
+    end
+
     private
+      attr_reader :update_raw_sql_aliased
       attr_reader :scope_attributes
 
       def has_attribute_aliases?(attributes)
@@ -294,6 +300,10 @@ module ActiveRecord
         end
 
         alias raw_update_sql? raw_update_sql
+
+        def raw_update_sql_aliased?
+          insert_all.update_raw_sql_aliased?
+        end
 
         private
           attr_reader :connection, :insert_all

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -359,8 +359,8 @@ module ActiveRecord
       #   ], unique_by: :isbn)
       #
       #   Book.find_by(isbn: "1").title # => "Eloquent Ruby"
-      def upsert_all(attributes, on_duplicate: :update, update_only: nil, returning: nil, unique_by: nil, record_timestamps: nil)
-        InsertAll.execute(self, attributes, on_duplicate: on_duplicate, update_only: update_only, returning: returning, unique_by: unique_by, record_timestamps: record_timestamps)
+      def upsert_all(attributes, on_duplicate: :update, update_only: nil, returning: nil, unique_by: nil, record_timestamps: nil, on_duplicate_raw_sql_aliased: false)
+        InsertAll.execute(self, attributes, on_duplicate: on_duplicate, update_only: update_only, returning: returning, unique_by: unique_by, record_timestamps: record_timestamps, on_duplicate_raw_sql_aliased: on_duplicate_raw_sql_aliased)
       end
 
       # Given an attributes hash, +instantiate+ returns a new instance of

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -794,7 +794,8 @@ class InsertAllTest < ActiveRecord::TestCase
 
     Book.upsert_all(
       [{ id: b1.id, name: "No Name" }, { id: b2.id, name: "No Name" }],
-      on_duplicate: Arel.sql("name = IFNULL(books.name, books_values.name)")
+      on_duplicate: Arel.sql("name = IFNULL(books.name, books_values.name)"),
+      on_duplicate_raw_sql_aliased: true
     )
 
     b1.reload

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -768,6 +768,42 @@ class InsertAllTest < ActiveRecord::TestCase
     assert_equal "written", Book.find(2).status
   end
 
+  def test_upsert_all_updates_using_values_function_on_duplicate_raw_sql
+    skip unless supports_insert_on_duplicate_update?
+
+    b1 = Book.create!(name: "Name")
+    b2 = Book.create!(name: nil)
+
+    Book.upsert_all(
+      [{ id: b1.id, name: "No Name" }, { id: b2.id, name: "No Name" }],
+      on_duplicate: Arel.sql("name = IFNULL(name, VALUES(name))")
+    )
+
+    b1.reload
+    b2.reload
+
+    assert_equal "Name", b1.name
+    assert_equal "No Name", b2.name
+  end
+
+  def test_upsert_all_updates_using_values_alias_on_duplicate_raw_sql
+    skip unless supports_insert_on_duplicate_update?
+
+    b1 = Book.create!(name: "Name")
+    b2 = Book.create!(name: nil)
+
+    Book.upsert_all(
+      [{ id: b1.id, name: "No Name" }, { id: b2.id, name: "No Name" }],
+      on_duplicate: Arel.sql("name = IFNULL(books.name, books_values.name)")
+    )
+
+    b1.reload
+    b2.reload
+
+    assert_equal "Name", b1.name
+    assert_equal "No Name", b2.name
+  end
+
   def test_upsert_all_updates_using_provided_sql_and_unique_by
     skip unless supports_insert_on_duplicate_update? && supports_insert_conflict_target?
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Following https://github.com/rails/rails/pull/51274/files#r1520277424, we started getting mixed queries when using raw SQL. For example:

```
Model.upsert_all(..., on_duplicate: Arel.sql("x=VALUES(x)"))
INSERT table (...) VALUES (...) as values_alias ON DUPLICATE KEY UPDATE x=VALUES(x)
```
and
```
Model.upsert_all(..., on_duplicate: Arel.sql("x=x"))
INSERT table (...) VALUES (...) as values_alias ON DUPLICATE KEY UPDATE x=x
```

Both cases cause:

```
ActiveRecord::StatementInvalid: Trilogy::ProtocolError: 1052: Column 'x' in field list is ambiguous
```

### Detail

In the case of raw SQL, I think using the old syntax without values aliases (previous behavior) is better since we can't determine whether it is aliased or not. For example: 

```
Model.upsert_all(..., on_duplicate: Arel.sql("x=VALUES(x)"))
INSERT table (...) VALUES (...) ON DUPLICATE KEY UPDATE x=VALUES(x)
```

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

To adopt the new syntax using raw SQL the user needs to inform that the clause is already aliased by setting `on_duplicate_raw_sql_aliased: true`

```diff
- Model.upsert_all(..., on_duplicate: Arel.sql("x=VALUES(x)"))
+ Model.upsert_all(..., on_duplicate: Arel.sql("x=values_alias.x"), on_duplicate_raw_sql_aliased: true)

- INSERT table (...) VALUES (...) ON DUPLICATE KEY UPDATE x=VALUES(x)
+ INSERT table (...) VALUES (...) as values_alias ON DUPLICATE KEY UPDATE x=values_alias.x)
```

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
